### PR TITLE
Cosmetics: Removed unnecessary const's on return type.

### DIFF
--- a/src/basic/head/colour_pair.h
+++ b/src/basic/head/colour_pair.h
@@ -358,7 +358,7 @@ class ColourPair
   /*!
    * return the \a maxStage 
    */
-  const size_t maxStage() const
+  size_t maxStage() const
   { 
     return m_maxStage;
   }
@@ -366,7 +366,7 @@ class ColourPair
   /*!
    * return the \a maxStage 
    */
-  const size_t maxStage_0() const
+  size_t maxStage_0() const
   { 
     return m_maxStage_0;
   }
@@ -374,7 +374,7 @@ class ColourPair
   /*!
    * return the \a m_maxBondedStage[icl] 
    */
-  const size_t maxBondedStage(size_t icl) const
+  size_t maxBondedStage(size_t icl) const
   { 
     return m_maxBondedStage[icl];
   }
@@ -382,7 +382,7 @@ class ColourPair
   /*!
    * return the \a m_maxBondedStage_0[icl] 
    */
-  const size_t maxBondedStage_0(size_t icl) const
+  size_t maxBondedStage_0(size_t icl) const
   { 
     return m_maxBondedStage_0[icl];
   }

--- a/src/basic/head/phase.h
+++ b/src/basic/head/phase.h
@@ -766,7 +766,7 @@ public:
   /*!
    * return the \a m_maxBondedStage[icl] 
    */
-  const size_t maxBondedStage(size_t icl) const
+  size_t maxBondedStage(size_t icl) const
   { 
     return m_maxBondedStage[icl];
   }
@@ -774,7 +774,7 @@ public:
   /*!
    * return the \a m_maxBondedStage_0[icl] 
    */
-  const size_t maxBondedStage_0(size_t icl) const
+  size_t maxBondedStage_0(size_t icl) const
   { 
     return m_maxBondedStage_0[icl];
   }


### PR DESCRIPTION
Hi David, icpc warned about these const statements which are not needed since the returned type is not mutable. Lars
